### PR TITLE
hmpope-28. Email-Step

### DIFF
--- a/acceptance_tests/codecept.json
+++ b/acceptance_tests/codecept.json
@@ -27,6 +27,7 @@
     "refNumberPage": "./pages/ref-number.js",
     "emailAddressPage": "./pages/email-address.js",
     "addressPage": "./pages/address.js",
-    "enquiryTypePage": "./pages/enquiry-type.js"
+    "enquiryTypePage": "./pages/enquiry-type.js",
+    "confirmPage": "./pages/confirm.js"
   }
 }

--- a/acceptance_tests/features/track-application/email-address.js
+++ b/acceptance_tests/features/track-application/email-address.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const JOURNEY_NAME = require('./content').name;
+
+Feature('Track Application / Email address');
+
+// eslint-disable-next-line max-params
+Before((
+  I,
+  emailAddressPage,
+  refNumberPage,
+  applyOnlinePage,
+  whoseApplicationPage,
+  applicantsFullNamePage
+) => {
+  I.visitPage(emailAddressPage, JOURNEY_NAME, [
+    applyOnlinePage,
+    whoseApplicationPage,
+    applicantsFullNamePage,
+    refNumberPage
+  ]);
+});
+
+Scenario('The correct form elements are present', (
+  I,
+  emailAddressPage
+) => {
+  I.seeElements([
+    emailAddressPage['email-address']
+  ]);
+});
+
+Scenario('I see the hint if I am the customer', function *(
+  I,
+  emailAddressPage
+) {
+  yield I.setSessionData(JOURNEY_NAME, {
+    representative: 'false'
+  });
+  I.refreshPage();
+  I.see(emailAddressPage.hint);
+});
+
+Scenario('I dont\'t see the hint if I am the customer', function *(
+  I,
+  emailAddressPage
+) {
+  yield I.setSessionData(JOURNEY_NAME, {
+    representative: 'true'
+  });
+  I.refreshPage();
+  I.dontSee(emailAddressPage.hint);
+});
+
+Scenario('An error is shown if email-address is not completed', (
+  I,
+  emailAddressPage
+) => {
+  I.submitForm();
+  I.seeErrors(emailAddressPage['email-address']);
+});
+
+Scenario('An error is shown if an invalid email-address in entered', (
+  I,
+  emailAddressPage
+) => {
+  emailAddressPage.fillFormAndSubmit(emailAddressPage.content.invalid);
+  I.seeErrors(emailAddressPage['email-address']);
+});
+
+Scenario('I am taken to the address step if I am a customer', function *(
+  I,
+  emailAddressPage,
+  addressPage
+) {
+  yield I.setSessionData(JOURNEY_NAME, {
+    representative: 'false'
+  });
+  I.refreshPage();
+  emailAddressPage.fillFormAndSubmit(emailAddressPage.content.valid);
+  I.seeInCurrentUrl(addressPage.url);
+});
+
+Scenario('I am taken to the confirm step if I am a representative', function *(
+  I,
+  emailAddressPage,
+  confirmPage
+) {
+  yield I.setSessionData(JOURNEY_NAME, {
+    representative: 'true'
+  });
+  I.refreshPage();
+  emailAddressPage.fillFormAndSubmit(emailAddressPage.content.valid);
+  I.seeInCurrentUrl(confirmPage.url);
+});

--- a/acceptance_tests/pages/confirm.js
+++ b/acceptance_tests/pages/confirm.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  url: 'confirm'
+};

--- a/acceptance_tests/pages/email-address.js
+++ b/acceptance_tests/pages/email-address.js
@@ -1,5 +1,27 @@
 'use strict';
 
+const TRANSLATIONS = require('../../apps/track-application/translations/en/default');
+const EMAIL_ADDRESS = TRANSLATIONS.fields['email-address'];
+
+let I;
+
 module.exports = {
-  url: 'email-address'
+
+  _init() {
+    I = require('../steps.js')();
+  },
+
+  url: 'email-address',
+  'email-address': '#email-address',
+  hint: EMAIL_ADDRESS.hint.representative.false,
+  content: {
+    invalid: 'invalid email',
+    valid: 'email@email.com'
+  },
+
+  fillFormAndSubmit(content) {
+    I.seeElement(this['email-address']);
+    I.fillField(this['email-address'], content);
+    I.submitForm();
+  }
 };

--- a/apps/track-application/fields.js
+++ b/apps/track-application/fields.js
@@ -39,5 +39,9 @@ module.exports = {
       field: 'no-ref-number',
       value: ''
     }
+  },
+  'email-address': {
+    mixin: 'input-text',
+    validate: ['required', 'email']
   }
 };

--- a/apps/track-application/index.js
+++ b/apps/track-application/index.js
@@ -62,11 +62,15 @@ module.exports = {
       next: '/representatives-full-name'
     },
     '/email-address': {
+      fields: ['email-address'],
       next: '/address',
       forks: [{
         target: '/confirm',
         condition: isRep
-      }]
+      }],
+      locals: {
+        section: 'track-application'
+      }
     },
     '/address': {
       next: '/confirm',

--- a/apps/track-application/translations/src/en/fields.json
+++ b/apps/track-application/translations/src/en/fields.json
@@ -33,5 +33,14 @@
   },
   "no-ref-number": {
     "label": "I don’t know the reference number"
+  },
+  "email-address": {
+    "label": "What's your email address?",
+    "hint": {
+      "representative": {
+        "false": "This must be the same as on the application form"
+      },
+      "default": ""
+    }
   }
 }


### PR DESCRIPTION
Added the email step to the hmpo form
- Added field and section to route config
- Added field validation to the field config
- Added translations for field with deepTranslation for the hint when it's a customer or a representative.
- Create acceptance tests for step.
- Updated the email-address page helper with element id, content and form submission.
- Added confirm page helper with just the url
