### PR TITLE
hmpope-48 Declaration content page

### DIFF
--- a/acceptance_tests/codecept.conf.js
+++ b/acceptance_tests/codecept.conf.js
@@ -7,6 +7,7 @@ const relative = relativePath => path.resolve(__dirname, relativePath);
 module.exports = {
   name: 'hmpo-enquiries',
   include: {
+    enquiryTypePage: relative('./pages/enquiry-type.js'),
     applyOnlinePage: relative('./pages/apply-online.js'),
     trackOnlinePage: relative('./pages/track-online.js'),
     whoseApplicationPage: relative('./pages/whose-application.js'),
@@ -17,7 +18,7 @@ module.exports = {
     applicantsDOBPage: relative('./pages/applicants-dob.js'),
     repsFullNamePage: relative('./pages/representatives-full-name.js'),
     relationshipPage: relative('./pages/relationship.js'),
-    enquiryTypePage: relative('./pages/enquiry-type.js'),
-    confirmPage: relative('./pages/confirm.js')
+    confirmPage: relative('./pages/confirm.js'),
+    replacementFormPage: relative('./pages/replacement-form.js')
   }
 };

--- a/acceptance_tests/features/request-declaration/replacement-form.js
+++ b/acceptance_tests/features/request-declaration/replacement-form.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const JOURNEY_NAME = require('./content').name;
+
+Feature('Apply online step');
+
+Before((
+  I,
+  replacementFormPage
+) => {
+  I.visitPage(replacementFormPage, JOURNEY_NAME);
+});
+
+Scenario('On submitting the form I am taken to the whose-application step', (
+  I,
+  whoseApplicationPage
+) => {
+  I.submitForm();
+  I.seeInCurrentUrl(whoseApplicationPage.url);
+});

--- a/acceptance_tests/pages/replacement-form.js
+++ b/acceptance_tests/pages/replacement-form.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  url: 'replacement-form'
+};

--- a/apps/enquiries/index.js
+++ b/apps/enquiries/index.js
@@ -13,7 +13,7 @@ module.exports = {
       fields: ['enquiry-type'],
       next: '/track-application/apply-online',
       forks: [{
-        target: '/request-declaration',
+        target: '/request-declaration/replacement-form',
         condition: {
           field: 'enquiry-type',
           value: 'replace'

--- a/apps/request-declaration/index.js
+++ b/apps/request-declaration/index.js
@@ -1,10 +1,15 @@
 'use strict';
 
 module.exports = {
-  name: 'request-declaration',
+  baseUrl: '/request-declaration',
   steps: {
-    '/request-declaration': {
-      fields: ['test-text'],
+    '/replacement-form': {
+      next: '/whose-application',
+      locals: {
+        section: 'request-declaration'
+      }
+    },
+    '/whose-application': {
       locals: {
         section: 'request-declaration'
       }

--- a/apps/request-declaration/translations/src/en/pages.json
+++ b/apps/request-declaration/translations/src/en/pages.json
@@ -1,5 +1,10 @@
 {
   "request-declaration": {
-    "header": "Request a replacement declaration form"
+    "header": "Request a replacement declaration form",
+    "replacement": {
+      "download": "If you applied for the passport online, you should have received a declaration form to download and print.",
+      "unable-to-print": "If you were unable to download or print your declaration form, you can request a replacement.",
+      "reference-number": "To use this service you will need the application reference number."
+    }
   }
 }

--- a/apps/request-declaration/views/replacement-form.html
+++ b/apps/request-declaration/views/replacement-form.html
@@ -1,0 +1,8 @@
+{{<partials-page}}
+  {{$page-content}}
+    <p>{{#t}}pages.request-declaration.replacement.download{{/t}}</p>
+    <p>{{#t}}pages.request-declaration.replacement.unable-to-print{{/t}}</p>
+    <p>{{#t}}pages.request-declaration.replacement.reference-number{{/t}}</p>
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
Created a step for the request replacement declaration form. This step is just a content page with a continue button. 
- Added step to route config,
- Added customer template for step,
- Added translations for step in pages translations file,
- Added acceptance test(and its helper) for step going to the next page
