### PR TITLE
Feature/hmpope 50 how to recieve

### DIFF
--- a/apps/common/acceptance/pages/how-to-receive.js
+++ b/apps/common/acceptance/pages/how-to-receive.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  url: 'how-to-receive',
+  'post-replacement': '#post-replacement-group',
+  'true': '#post-replacement-true',
+  'false': '#post-replacement-false'
+};

--- a/apps/common/acceptance/pages/send-replacement.js
+++ b/apps/common/acceptance/pages/send-replacement.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  url: 'send-replacement'
-};

--- a/apps/request-declaration/acceptance/features/how-to-receive.js
+++ b/apps/request-declaration/acceptance/features/how-to-receive.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const steps = require('../../');
+
+Feature('Request a replacement declaration form / Send Replacement');
+
+Before((
+  I,
+  howToReceivePage
+) => {
+  I.visitPage(howToReceivePage, steps);
+});
+
+Scenario('The correct form elements are present', (
+  I,
+  howToReceivePage
+) => {
+  I.seeElements([
+    howToReceivePage['post-replacement'],
+    howToReceivePage.true,
+    howToReceivePage.false
+  ]);
+});
+
+Scenario('An error is shown if how-to-receive is not completed', (
+  I,
+  howToReceivePage
+) => {
+  I.submitForm();
+  I.seeErrors(howToReceivePage['post-replacement']);
+});
+
+Scenario('When I select any option I am taken to the applicants-full-name step', (
+  I,
+  howToReceivePage,
+  applicantsFullNamePage
+) => {
+  I.checkOption(howToReceivePage.false);
+  I.submitForm();
+  I.seeInCurrentUrl(applicantsFullNamePage.url);
+});

--- a/apps/request-declaration/acceptance/features/whose-application.js
+++ b/apps/request-declaration/acceptance/features/whose-application.js
@@ -30,12 +30,12 @@ Scenario('The /whose-application step shows error message when continuing withou
   I.seeErrors(whoseApplicationPage.representative);
 });
 
-Scenario('When I select any option I am taken to the send-replacement step', (
+Scenario('When I select any option I am taken to the how-to-receive step', (
   I,
   whoseApplicationPage,
-  sendReplacementPage
+  howToReceivePage
 ) => {
   I.checkOption(whoseApplicationPage.false);
   I.submitForm();
-  I.seeInCurrentUrl(sendReplacementPage.url);
+  I.seeInCurrentUrl(howToReceivePage.url);
 });

--- a/apps/request-declaration/fields.js
+++ b/apps/request-declaration/fields.js
@@ -12,5 +12,17 @@ module.exports = {
       value: 'true',
       label: 'fields.representative.options.true'
     }]
+  },
+  'post-replacement': {
+    mixin: 'radio-group',
+    validate: ['required'],
+    className: ['form-group'],
+    options: [{
+      value: 'false',
+      label: 'fields.post-replacement.options.false'
+    }, {
+      value: 'true',
+      label: 'fields.post-replacement.options.true'
+    }]
   }
 };

--- a/apps/request-declaration/index.js
+++ b/apps/request-declaration/index.js
@@ -12,12 +12,13 @@ module.exports = {
     },
     '/whose-application': {
       fields: ['representative'],
-      next: '/send-replacement',
+      next: '/how-to-receive',
       locals: {
         section: 'request-declaration'
       }
     },
-    '/send-replacement': {
+    '/how-to-receive': {
+      fields: ['post-replacement'],
       next: '/applicants-full-name',
       locals: {
         section: 'request-declaration'

--- a/apps/request-declaration/translations/src/en/fields.json
+++ b/apps/request-declaration/translations/src/en/fields.json
@@ -5,5 +5,12 @@
       "true": "Someone else's passport application",
       "false": "My passport application"
     }
+  },
+  "post-replacement": {
+    "legend": "How would you like us to send you a replacement declaration form?",
+    "options": {
+      "true": "Send me a replacement in the post",
+      "false": "Email me a replacement so I can print it myself"
+    }
   }
 }

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -22,6 +22,6 @@ module.exports = {
     enquiryTypePage: pagesPath('enquiry-type.js'),
     confirmPage: pagesPath('confirm.js'),
     replacementFormPage: pagesPath('replacement-form.js'),
-    sendReplacementPage: pagesPath('send-replacement.js')
+    howToReceivePage: pagesPath('how-to-receive.js')
   }
 };


### PR DESCRIPTION
Added the how to receive step
Was originally called send-replacement. So changed all references of this to 'how-tor-receive'
- Added the step route config,
- Added the field and validation to the fields config,
- Added the fields translations,
- Added the acceptance tests for the step and it's helper
