### PR TITLE
hmpope-53 Email-address

### DIFF
--- a/apps/common/fields.js
+++ b/apps/common/fields.js
@@ -9,4 +9,8 @@ module.exports = {
     mixin: 'input-text',
     validate: ['required']
   },
+  'email-address': {
+    mixin: 'input-text',
+    validate: ['required', 'email']
+  }
 };

--- a/apps/common/translations/src/en/fields.json
+++ b/apps/common/translations/src/en/fields.json
@@ -15,5 +15,14 @@
   },
   "representatives-full-name": {
     "label": "What's your full name?"
+  },
+  "email-address": {
+    "label": "What's your email address?",
+    "hint": {
+      "representative": {
+        "false": "This must be the same as on the application form"
+      },
+      "default": ""
+    }
   }
 }

--- a/apps/request-declaration/acceptance/features/email-address.js
+++ b/apps/request-declaration/acceptance/features/email-address.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const steps = require('../../');
+
+Feature('Request a replacement declaration form / Email address');
+
+Before((
+  I,
+  emailAddressPage
+) => {
+  I.visitPage(emailAddressPage, steps);
+});
+
+Scenario('The correct form elements are present', (
+  I,
+  emailAddressPage
+) => {
+  I.seeElements([
+    emailAddressPage['email-address']
+  ]);
+});
+
+Scenario('I see the hint if I am the customer', function *(
+  I,
+  emailAddressPage
+) {
+  yield I.setSessionData(steps.name, {
+    representative: 'false'
+  });
+  yield I.refreshPage();
+  I.seeHint(emailAddressPage['email-address']);
+});
+
+Scenario('I dont\'t see the hint if I am the customer', function *(
+  I,
+  emailAddressPage
+) {
+  yield I.setSessionData(steps.name, {
+    representative: 'true'
+  });
+  yield I.refreshPage();
+  I.dontSeeHint(emailAddressPage['email-address']);
+});
+
+Scenario('An error is shown if email-address is not completed', (
+  I,
+  emailAddressPage
+) => {
+  I.submitForm();
+  I.seeErrors(emailAddressPage['email-address']);
+});
+
+Scenario('An error is shown if an invalid email-address in entered', (
+  I,
+  emailAddressPage
+) => {
+  emailAddressPage.fillFormAndSubmit(emailAddressPage.content.invalid);
+  I.seeErrors(emailAddressPage['email-address']);
+});
+
+Scenario('I am taken to the confirm step', function *(
+  I,
+  emailAddressPage,
+  confirmPage
+) {
+  yield I.setSessionData(steps.name, {
+    representative: 'true'
+  });
+  yield I.refreshPage();
+  emailAddressPage.fillFormAndSubmit(emailAddressPage.content.valid);
+  I.seeInCurrentUrl(confirmPage.url);
+});

--- a/apps/request-declaration/index.js
+++ b/apps/request-declaration/index.js
@@ -53,6 +53,11 @@ module.exports = {
       }
     },
     '/email-address': {
+      fields: ['email-address'],
+      next: '/confirm',
+      locals: {
+        section: 'request-declaration'
+      }
     },
     '/address': {
     },
@@ -77,6 +82,8 @@ module.exports = {
       locals: {
         section: 'request-declaration'
       }
+    },
+    '/confirm': {
     }
   }
 };

--- a/apps/track-application/fields.js
+++ b/apps/track-application/fields.js
@@ -36,10 +36,6 @@ module.exports = {
       value: ''
     }
   },
-  'email-address': {
-    mixin: 'input-text',
-    validate: ['required', 'email']
-  },
   'dob': {},
   'dob-day': {
     validate: ['required', 'numeric']

--- a/apps/track-application/translations/src/en/fields.json
+++ b/apps/track-application/translations/src/en/fields.json
@@ -20,15 +20,6 @@
   "no-ref-number": {
     "label": "I don’t know the reference number"
   },
-  "email-address": {
-    "label": "What's your email address?",
-    "hint": {
-      "representative": {
-        "false": "This must be the same as on the application form"
-      },
-      "default": ""
-    }
-  },
   "dob": {
     "legend": "What is the applicant's date of birth?",
     "hint": "(DD/MM/YYYY)"


### PR DESCRIPTION
Added email-address step to the request declaration form journey.
- Added step to routes config,
- Moved the email address field and translations out of 'track-application' and into common,
- Added step acceptance tests for the step
