### PR TITLE
hmpope-56 Add reps-full-name step

### DIFF
--- a/apps/common/acceptance/features/representatives-full-name.js
+++ b/apps/common/acceptance/features/representatives-full-name.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const steps = {
+  name: 'common',
+  steps: require('../../')
+};
+
+Feature('Representatives Full Name');
+
+Before((
+  I,
+  repsFullNamePage
+) => {
+  I.visitPage(repsFullNamePage, steps);
+});
+
+Scenario('The correct form elements are present', (
+  I,
+  repsFullNamePage
+) => {
+  I.seeElements(repsFullNamePage['representatives-full-name']);
+});
+
+Scenario('An error is shown if representatives-full-name is not completed', (
+  I,
+  repsFullNamePage
+) => {
+  I.submitForm();
+  I.seeErrors(repsFullNamePage['representatives-full-name']);
+});

--- a/apps/request-declaration/acceptance/features/representatives-full-name.js
+++ b/apps/request-declaration/acceptance/features/representatives-full-name.js
@@ -2,7 +2,7 @@
 
 const steps = require('../../');
 
-Feature('Track Application / Representatives Full Name');
+Feature('Request a replacement declaration form / Representatives Full Name');
 
 Before((
   I,

--- a/apps/request-declaration/index.js
+++ b/apps/request-declaration/index.js
@@ -68,6 +68,9 @@ module.exports = {
       }
     },
     '/representatives-full-name': {
+      fields: [
+        'representatives-full-name'
+      ],
       next: '/relationship',
       locals: {
         section: 'request-declaration'

--- a/apps/track-application/translations/src/en/fields.json
+++ b/apps/track-application/translations/src/en/fields.json
@@ -33,9 +33,6 @@
   "dob-year": {
     "label": " "
   },
-  "representatives-full-name": {
-    "label": "What's your full name?"
-  },
   "relationship": {
     "label": "What's your relationship to the applicant?"
   }


### PR DESCRIPTION
Added reps full name step to the request declaration journey:
- Added field to route config,
- Moved translations for track-application journey to common,
- Moved acceptance tests to common but kept acceptance tests for next step within the journey
