### PR TITLE
Feature/hmpope29 address lookup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ pipeline:
   build_4:
     image: node:4.4.2
     commands:
-      - npm --loglevel warn install -g npm@3
+      - npm --loglevel warn install -g npm@3.10.8
       - npm --loglevel warn install
       - npm run test:ci
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 extends:
 - "homeoffice/config/default"
 
+rules:
+  consistent-return: off
+
 env:
   es6: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum clean all && \
   yum install -y -q git && \
   yum clean all && \
   rpm --rebuilddb && \
-  npm --loglevel warn install -g npm@3
+  npm --loglevel warn install -g npm@3.10.8
 
 COPY package.json /app/package.json
 RUN npm --loglevel warn install --production --no-optional

--- a/Dockerfile-acceptance
+++ b/Dockerfile-acceptance
@@ -10,6 +10,8 @@ RUN wget https://github.com/Medium/phantomjs/releases/download/v2.1.1/${PHANTOM_
 COPY package.json package.json
 COPY test.sh test.sh
 COPY codecept.conf.js codecept.conf.js
+COPY config.js config.js
+COPY mock-postcode.js mock-postcode.js
 COPY apps apps/
 
 RUN npm --loglevel warn install --ignore-scripts

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const path = require('path');
 const bootstrap = require('hof-bootstrap');
 const config = require('./config.js');
 const mockPostcode = require('./mock-postcode.js');
@@ -16,8 +17,8 @@ const routes = [
 ];
 
 const options = {
-  views: './apps/common/views',
-  fields: './apps/common/fields',
+  views: path.resolve(__dirname, './apps/common/views'),
+  fields: path.resolve(__dirname, './apps/common/fields'),
   routes
 };
 

--- a/app.js
+++ b/app.js
@@ -2,6 +2,8 @@
 
 const _ = require('lodash');
 const bootstrap = require('hof-bootstrap');
+const config = require('./config.js');
+const mockPostcode = require('./mock-postcode.js');
 
 const routes = [
   require('./apps/enquiries/'),
@@ -13,18 +15,24 @@ const routes = [
   require('./apps/contact-us')
 ];
 
-// eslint-disable-next-line no-process-env
-if (process.env.NODE_ENV === 'ci') {
-  routes.unshift({
+const options = {
+  views: './apps/common/views',
+  fields: './apps/common/fields',
+  routes
+};
+
+if (config.env === 'ci') {
+  options.routes.unshift({
     name: 'common',
+    params: '/:action?',
     steps: _.mapValues(Object.assign({}, require('./apps/common'), {
       '/empty': {}
     }), value => Object.assign(value, {next: '/blank'}))
   });
+
+  options.middleware = [
+    mockPostcode
+  ];
 }
 
-module.exports = bootstrap({
-  views: false,
-  fields: './apps/common/fields',
-  routes
-});
+bootstrap(options);

--- a/apps/common/acceptance/features/postcode.js
+++ b/apps/common/acceptance/features/postcode.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const steps = {
+  name: 'common',
+  steps: require('../../')
+};
+
+Feature('Postcode');
+
+Before((
+  I,
+  postcodePage
+) => {
+  I.visitPage(postcodePage, steps);
+});
+
+Scenario('The correct form elements are present on postcode step', (
+  I,
+  postcodePage
+) => {
+  I.seeElements([
+    postcodePage.fields.postcode
+  ]);
+});
+
+Scenario('I see the customer header if I am the customer', function *(
+  I,
+  postcodePage
+) {
+  yield I.setSessionData(steps.name, {
+    representative: 'false'
+  });
+  I.refreshPage();
+  I.see(postcodePage.header.customer);
+});
+
+Scenario('I see the representative header if I am the representative', function *(
+  I,
+  postcodePage
+) {
+  yield I.setSessionData(steps.name, {
+    representative: 'true'
+  });
+  I.refreshPage();
+  I.see(postcodePage.header.representative);
+});
+
+Scenario('An error is shown if postcode is not completed', (
+  I,
+  postcodePage
+) => {
+  I.submitForm();
+  I.seeErrors(postcodePage.fields.postcode);
+});
+
+Scenario('I am taken to the manual-address step when I click the link', (
+  I,
+  postcodePage
+) => {
+  I.click(postcodePage.links['manual-entry']);
+  I.seeInCurrentUrl(postcodePage['address-url']);
+});
+
+Scenario('The correct form elements are present for manual address', (
+  I,
+  postcodePage
+) => {
+  I.click(postcodePage.links['manual-entry']);
+  I.seeElements([
+    postcodePage.fields['address-manual']
+  ]);
+});
+
+Scenario('An error is shown if manual address is not completed', (
+  I,
+  postcodePage
+) => {
+  I.click(postcodePage.links['manual-entry']);
+  I.submitForm();
+  I.seeErrors(postcodePage.fields['address-manual']);
+});
+
+Scenario('I am taken to the address-lookup step from postcode', (
+  I,
+  postcodePage
+) => {
+  postcodePage.fillFormAndSubmit(postcodePage.fields.postcode);
+  I.seeInCurrentUrl(postcodePage['address-lookup-url']);
+});
+
+Scenario('An error is shown if address-lookup is not completed', (
+  I,
+  postcodePage
+) => {
+  postcodePage.fillFormAndSubmit(postcodePage.fields.postcode);
+  I.submitForm();
+  I.seeErrors(postcodePage.fields['address-lookup']);
+});
+
+Scenario('I am taken to the manual address step if I cant find my address', (
+  I,
+  postcodePage
+) => {
+  postcodePage.fillFormAndSubmit(postcodePage.fields.postcode);
+  I.click(postcodePage.links['cant-find-address']);
+  I.seeInCurrentUrl(postcodePage['address-url']);
+});
+
+Scenario('When I click cant find my address link, I will see the postcode I entered in the manual address step', (
+  I,
+  postcodePage
+) => {
+  postcodePage.fillFormAndSubmit(postcodePage.fields.postcode);
+  I.click(postcodePage.links['cant-find-address']);
+  I.see(postcodePage.content.postcode);
+});

--- a/apps/common/acceptance/pages/address.js
+++ b/apps/common/acceptance/pages/address.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  url: 'address'
-};

--- a/apps/common/acceptance/pages/postcode.js
+++ b/apps/common/acceptance/pages/postcode.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const TRANSLATIONS = require('../../../track-application/translations/en/default');
+const ADDRESS = TRANSLATIONS.pages.address;
+
+let I;
+
+module.exports = {
+
+  _init() {
+    I = require('so-acceptance/steps')();
+  },
+
+  url: 'postcode',
+  'address-url': 'address',
+  'address-lookup-url': 'address-lookup',
+  fields: {
+    postcode: '#postcode-code',
+    'address-lookup': '#address-lookup',
+    'address-manual': '#address-manual'
+  },
+  links: {
+    'manual-entry': '#manual-entry',
+    'cant-find-address': '#cant-find'
+  },
+  header: {
+    customer: ADDRESS.header.representative.false,
+    representative: ADDRESS.header.default
+  },
+  content: {
+    postcode: 'CR0 2EU',
+    address: '49 Sydenham Road, Croydon, CR0 2EU'
+  },
+
+  fillFormAndSubmit(field) {
+    I.fillField(field, this.content.postcode);
+    I.submitForm();
+  },
+
+  selectAddressAndSubmit() {
+    this.fillFormAndSubmit(this.fields.postcode);
+    I.selectOption(this.fields['address-lookup'], this.content.address);
+    I.submitForm();
+  }
+};

--- a/apps/common/controllers/address-lookup.js
+++ b/apps/common/controllers/address-lookup.js
@@ -29,6 +29,6 @@ module.exports = class AddressLookup extends BaseController {
         redirect: undefined
       });
     }
-    return undefined;
+    return;
   }
 };

--- a/apps/common/controllers/address-lookup.js
+++ b/apps/common/controllers/address-lookup.js
@@ -1,0 +1,34 @@
+'use strict';
+const BaseController = require('hof').controllers.base;
+const ErrorController = require('hof').controllers.error;
+const _ = require('lodash');
+
+module.exports = class AddressLookup extends BaseController {
+
+  getValues(req, res, callback) {
+    const addresses = req.sessionModel.get('addresses');
+    const formattedlist = _.map(_.map(addresses, 'formatted_address'), arg => arg.split('\n').join(', '));
+
+    const count = `${formattedlist.length} addresses`;
+    this.options.fields['address-lookup'].options = [count].concat(formattedlist);
+    super.getValues(req, res, callback);
+  }
+
+  saveValues(req, res, callback) {
+    const addressLines = req.form.values['address-lookup'].split(', ').join('\n');
+    req.sessionModel.set('address-manual', addressLines);
+
+    super.saveValues(req, res, callback);
+  }
+
+  validateField(key, req) {
+    if (req.form.values[key] === this.options.fields['address-lookup'].options[0]) {
+      return new ErrorController('address-lookup', {
+        key: 'address-lookup',
+        type: 'required',
+        redirect: undefined
+      });
+    }
+    return undefined;
+  }
+};

--- a/apps/common/controllers/address.js
+++ b/apps/common/controllers/address.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const BaseController = require('hof').controllers.base;
+
+module.exports = class AddressController extends BaseController {
+  getValues(req, res, callback) {
+    if (req.params.action === 'manual') {
+      req.sessionModel.unset([
+        'postcode-code',
+        'postcodeApiMeta'
+      ]);
+    }
+    super.getValues(req, res, callback);
+  }
+
+  locals(req, res, callback) {
+    const isManual = req.params.action === 'manual';
+    const locals = super.locals(req, res, callback);
+    return Object.assign({}, locals, {
+      postcodeApiMessageKey: isManual ? '' : (req.sessionModel.get('postcodeApiMeta') || {}).messageKey
+    });
+  }
+};

--- a/apps/common/controllers/postcode.js
+++ b/apps/common/controllers/postcode.js
@@ -24,7 +24,7 @@ module.exports = class PostcodeController extends BaseController {
     }
 
     const postcodesModel = new PostcodesModel();
-    postcodesModel.fetch({postcode})
+    postcodesModel.fetch(postcode)
       .then(data => {
         if (data.length) {
           req.sessionModel.set('addresses', data);

--- a/apps/common/controllers/postcode.js
+++ b/apps/common/controllers/postcode.js
@@ -1,0 +1,48 @@
+/* eslint consistent-return: 0 */
+
+'use strict';
+
+const controllers = require('hof').controllers;
+const BaseController = controllers.base;
+const PostcodesModel = require('../models/postcodes');
+const logger = require('../../../node_modules/hof-bootstrap/lib/logger');
+const _ = require('lodash');
+
+module.exports = class PostcodeController extends BaseController {
+  process(req, res, callback) {
+    const postcode = req.form.values['postcode-code'];
+    const previousPostcode = req.sessionModel.get('postcode-code');
+    if (!postcode
+      || previousPostcode && previousPostcode === postcode) {
+      return callback();
+    }
+
+    if (_.startsWith(postcode, 'BT')) {
+      req.sessionModel.unset('postcodeApiMeta');
+      req.sessionModel.unset('addresses');
+      return callback();
+    }
+
+    const postcodesModel = new PostcodesModel();
+    postcodesModel.fetch({postcode})
+      .then(data => {
+        if (data.length) {
+          req.sessionModel.set('addresses', data);
+        } else {
+          req.sessionModel.unset('addresses');
+          req.sessionModel.set('postcodeApiMeta', {
+            messageKey: 'not-found'
+          });
+        }
+        return callback();
+      })
+      .catch(err => {
+        req.sessionModel.set('postcodeApiMeta', {
+          messageKey: 'cant-connect'
+        });
+        logger.error('Postcode lookup error: ',
+          `Code: ${err.status}; Detail: ${err.detail}`);
+        return callback();
+      });
+  }
+};

--- a/apps/common/fields.js
+++ b/apps/common/fields.js
@@ -22,7 +22,11 @@ module.exports = {
     mixin: 'textarea',
     validate: ['required'],
     'ignore-defaults': true,
-    formatter: ['trim', 'hyphens']
+    formatter: ['trim', 'hyphens'],
+    attributes: [{
+      attribute: 'height',
+      value: 6
+    }]
   },
   'address-lookup': {
     className: ['address'],

--- a/apps/common/fields.js
+++ b/apps/common/fields.js
@@ -12,5 +12,19 @@ module.exports = {
   'email-address': {
     mixin: 'input-text',
     validate: ['required', 'email']
+  },
+  'postcode-code': {
+    mixin: 'input-text-code',
+    validate: ['required', 'postcode'],
+    formatter: 'uppercase'
+  },
+  'address-manual': {
+    mixin: 'textarea',
+    validate: ['required'],
+    'ignore-defaults': true,
+    formatter: ['trim', 'hyphens']
+  },
+  'address-lookup': {
+    className: ['address'],
   }
 };

--- a/apps/common/index.js
+++ b/apps/common/index.js
@@ -15,5 +15,39 @@ module.exports = {
     fields: [
       'email-address'
     ]
-  }
+  },
+  '/postcode': {
+    controller: require('./controllers/postcode'),
+    fields: [
+      'postcode-code'
+    ],
+    forks: [{
+      target: '/address-lookup',
+      condition(req) {
+        const addresses = req.sessionModel.get('addresses');
+        return addresses && addresses.length;
+      }
+    }],
+    next: '/address',
+    locals: {
+      subsection: 'address'
+    }
+  },
+  '/address-lookup': {
+    controller: require('./controllers/address-lookup'),
+    fields: [
+      'address-lookup'
+    ],
+    locals: {
+      subsection: 'address'
+    }
+  },
+  '/address': {
+    fields: [
+      'address-manual'
+    ],
+    locals: {
+      subsection: 'address'
+    }
+  },
 };

--- a/apps/common/models/postcodes.js
+++ b/apps/common/models/postcodes.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const Model = require('hof').Model;
+const config = require('../../../config');
+const url = require('url');
+
+module.exports = class PostcodesModel extends Model {
+  fetch(options) {
+    options = options || {};
+    return new Promise((resolve, reject) => {
+      options = Object.assign({}, options, {
+        url: options.url || config.postcode.hostname + config.postcode.addresses.path,
+        query: {
+          postcode: options.postcode
+        }
+      });
+      const reqConf = url.parse(this.url(options));
+
+      reqConf.method = 'GET';
+      reqConf.headers = {
+        Authorization: config.postcode.authorization || ''
+      };
+      this.request(reqConf, (err, data) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(data);
+      });
+    });
+  }
+};

--- a/apps/common/models/postcodes.js
+++ b/apps/common/models/postcodes.js
@@ -5,13 +5,12 @@ const config = require('../../../config');
 const url = require('url');
 
 module.exports = class PostcodesModel extends Model {
-  fetch(options) {
-    options = options || {};
+  fetch(postcode) {
     return new Promise((resolve, reject) => {
-      options = Object.assign({}, options, {
-        url: options.url || config.postcode.hostname + config.postcode.addresses.path,
+      const options = Object.assign({}, {
+        url: config.postcode.hostname + config.postcode.addresses.path,
         query: {
-          postcode: options.postcode
+          postcode: postcode
         }
       });
       const reqConf = url.parse(this.url(options));

--- a/apps/common/models/postcodes.js
+++ b/apps/common/models/postcodes.js
@@ -7,13 +7,13 @@ const url = require('url');
 module.exports = class PostcodesModel extends Model {
   fetch(postcode) {
     return new Promise((resolve, reject) => {
-      const options = Object.assign({}, {
+      const postcodeAPI = {
         url: config.postcode.hostname + config.postcode.addresses.path,
         query: {
-          postcode: postcode
+          postcode
         }
-      });
-      const reqConf = url.parse(this.url(options));
+      };
+      const reqConf = url.parse(this.url(postcodeAPI));
 
       reqConf.method = 'GET';
       reqConf.headers = {

--- a/apps/common/models/postcodes.js
+++ b/apps/common/models/postcodes.js
@@ -7,13 +7,13 @@ const url = require('url');
 module.exports = class PostcodesModel extends Model {
   fetch(postcode) {
     return new Promise((resolve, reject) => {
-      const postcodeAPI = {
+      const attributes = {
         url: config.postcode.hostname + config.postcode.addresses.path,
         query: {
           postcode
         }
       };
-      const reqConf = url.parse(this.url(postcodeAPI));
+      const reqConf = url.parse(this.url(attributes));
 
       reqConf.method = 'GET';
       reqConf.headers = {

--- a/apps/common/translations/src/en/fields.json
+++ b/apps/common/translations/src/en/fields.json
@@ -24,5 +24,20 @@
       },
       "default": ""
     }
+  },
+  "postcode-code": {
+    "label": "Postcode",
+    "hint": "This must be the same as on the application form"
+  },
+  "address-lookup": {
+    "label": {
+      "representative": {
+        "false": "Select your address"
+      },
+      "default": "Select the applicant's address"
+    }
+  },
+  "address-manual": {
+    "label": "Address"
   }
 }

--- a/apps/common/translations/src/en/pages.json
+++ b/apps/common/translations/src/en/pages.json
@@ -1,0 +1,24 @@
+{
+  "address": {
+    "header": {
+      "representative": {
+        "false": "What's your full address?"
+      },
+      "default": "What's the applicant's full address?"
+    },
+    "edit": "Change",
+    "cantfind": {
+      "representative": {
+        "false": "I can't find my address in the list"
+      },
+      "default": "I can't find the address in the list"
+    },
+    "postcode-api": {
+      "not-found": "Sorry – we couldn’t find any addresses for that postcode, enter your address manually",
+      "cant-connect": "Sorry – we couldn’t connect to the postcode lookup service at this time, enter your address manually"
+    }
+  },
+  "postcode": {
+    "manual": "Enter address manually"
+  }
+}

--- a/apps/common/views/address-lookup.html
+++ b/apps/common/views/address-lookup.html
@@ -1,0 +1,17 @@
+{{<partials-page}}
+  {{$page-content}}
+    <label>
+      {{#t}}fields.postcode-code.label{{/t}}
+    </label>
+    <p>
+      <span class="postcode">{{values.postcode-code}}</span>
+      <span class="link"><a href="{{baseUrl}}/postcode">{{#t}}pages.address.edit{{/t}}</a></span>
+    </p>
+
+    {{#select}}address-lookup{{/select}}
+
+    <p><span id="cant-find" class="link"><a href="{{baseUrl}}/address">{{#t}}pages.address.cantfind{{/t}}</a></span></p>
+
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/common/views/address.html
+++ b/apps/common/views/address.html
@@ -1,0 +1,24 @@
+{{<partials-page}}
+  {{$page-content}}
+      {{#values.postcode-code}}
+        <label>
+          {{#t}}fields.postcode-code.label{{/t}}
+        </label>
+        <p>
+          <span class="postcode">{{values.postcode-code}}</span>
+          <span class="link"><a href="{{baseUrl}}/postcode">{{#t}}pages.address.edit{{/t}}</a></span>
+        </p>
+      {{/values.postcode-code}}
+      {{#postcodeApiMessageKey}}
+        <div class="alert-info">
+          <span class="info-message">
+            {{#t}}pages.address.postcode-api.{{postcodeApiMessageKey}}{{/t}}
+          </span>
+        </div>
+      {{/postcodeApiMessageKey}}
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/common/views/postcode.html
+++ b/apps/common/views/postcode.html
@@ -1,0 +1,13 @@
+{{<partials-page}}
+  {{$page-content}}
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    <p>
+      <span class="link">
+        <a id='manual-entry' href="{{baseUrl}}/address/manual">{{#t}}pages.postcode.manual{{/t}}</a>
+      </span>
+    </p>
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/request-declaration/acceptance/features/ref-number.js
+++ b/apps/request-declaration/acceptance/features/ref-number.js
@@ -45,7 +45,7 @@ Scenario('I am taken to the email-address step if I am the customer and I have s
 Scenario('I am taken to the address step if I am the customer and I have selected post on how-to-receive', function *(
   I,
   refNumberPage,
-  addressPage
+  postcodePage
 ){
   yield I.setSessionData(steps.name, {
     representative: 'false',
@@ -53,7 +53,7 @@ Scenario('I am taken to the address step if I am the customer and I have selecte
   });
   yield I.refreshPage();
   refNumberPage.fillFormAndSubmit()
-  I.seeInCurrentUrl(addressPage.url);
+  I.seeInCurrentUrl(postcodePage.url);
 });
 
 Scenario('I am taken to the applicants-dob step if I am the representative', function *(

--- a/apps/request-declaration/index.js
+++ b/apps/request-declaration/index.js
@@ -43,7 +43,7 @@ module.exports = {
           return !isPost(req) && !isRep(req);
         }
       }, {
-        target: '/address',
+        target: '/postcode',
         condition(req) {
           return isPost(req) && !isRep(req);
         }
@@ -59,7 +59,7 @@ module.exports = {
         section: 'request-declaration'
       }
     },
-    '/address': {
+    '/postcode': {
     },
     '/applicants-dob': {
       next: '/representatives-full-name',
@@ -76,7 +76,7 @@ module.exports = {
     '/relationship': {
       next: '/email-address',
       forks: [{
-        target: '/address',
+        target: '/postcode',
         condition: isPost
       }],
       locals: {

--- a/apps/track-application/acceptance/features/email-address.js
+++ b/apps/track-application/acceptance/features/email-address.js
@@ -11,17 +11,17 @@ Before((
   I.visitPage(emailAddressPage, steps);
 });
 
-Scenario('I am taken to the address step if I am a customer', function *(
+Scenario('I am taken to the postcode step if I am a customer', function *(
   I,
   emailAddressPage,
-  addressPage
+  postcodePage
 ) {
   yield I.setSessionData(steps.name, {
     representative: 'false'
   });
   yield I.refreshPage();
   emailAddressPage.fillFormAndSubmit(emailAddressPage.content.valid);
-  I.seeInCurrentUrl(addressPage.url);
+  I.seeInCurrentUrl(postcodePage.url);
 });
 
 Scenario('I am taken to the confirm step if I am a representative', function *(

--- a/apps/track-application/acceptance/features/postcode.js
+++ b/apps/track-application/acceptance/features/postcode.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const steps = require('../../');
+
+Feature('Track Application / Postcode');
+
+Before((
+  I,
+  postcodePage
+) => {
+  I.visitPage(postcodePage, steps);
+});
+
+Scenario('I am taken to the confirm step from the manual address', (
+  I,
+  postcodePage,
+  confirmPage
+) => {
+  I.click(postcodePage.links['manual-entry']);
+  postcodePage.fillFormAndSubmit(postcodePage.fields['address-manual']);
+  I.seeInCurrentUrl(confirmPage.url);
+});
+
+Scenario('When an address is selected I am taken to the confirm step', (
+  I,
+  postcodePage,
+  confirmPage
+) => {
+  postcodePage.selectAddressAndSubmit();
+  I.seeInCurrentUrl(confirmPage.url);
+});

--- a/apps/track-application/acceptance/features/ref-number.js
+++ b/apps/track-application/acceptance/features/ref-number.js
@@ -52,15 +52,15 @@ Scenario('I am taken to the email-address step if I am the customer', function *
   I.seeInCurrentUrl(emailAddressPage.url);
 });
 
-Scenario('I am taken to the address step if I am the representative', function *(
+Scenario('I am taken to the postcode step if I am the representative', function *(
   I,
   refNumberPage,
-  addressPage
+  postcodePage
 ) {
   yield I.setSessionData(steps.name, {
     representative: 'true'
   });
   yield I.refreshPage();
   refNumberPage.fillFormAndSubmit();
-  I.seeInCurrentUrl(addressPage.url);
+  I.seeInCurrentUrl(postcodePage.url);
 });

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -43,25 +43,12 @@ h1 {
 }
 
 select.address {
-  margin: 0 0.6em 0 0;
-  max-width: 100%;
-  overflow: hidden;
   border: 1px solid #aaa;
   font-family: "nta",Arial,sans-serif;
   font-size: 19px;
-  line-height: 1.31579;
-  font-weight: 400;
-  text-transform: none;
-  display: block;
-  width: auto;
 }
 
 span.postcode {
-  text-transform: uppercase;
   font-weight: bold;
   margin-right: 0.5em;
-}
-
-#address-textarea {
-  height: 6em;
 }

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -41,3 +41,27 @@ h1 {
 .form-label-bold {
   @include core-19;
 }
+
+select.address {
+  margin: 0 0.6em 0 0;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid #aaa;
+  font-family: "nta",Arial,sans-serif;
+  font-size: 19px;
+  line-height: 1.31579;
+  font-weight: 400;
+  text-transform: none;
+  display: block;
+  width: auto;
+}
+
+span.postcode {
+  text-transform: uppercase;
+  font-weight: bold;
+  margin-right: 0.5em;
+}
+
+#address-textarea {
+  height: 6em;
+}

--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -15,7 +15,7 @@ module.exports = {
     applicantsFullNamePage: pagesPath('applicants-full-name.js'),
     refNumberPage: pagesPath('ref-number.js'),
     emailAddressPage: pagesPath('email-address.js'),
-    addressPage: pagesPath('address.js'),
+    postcodePage: pagesPath('postcode.js'),
     applicantsDobPage: pagesPath('applicants-dob.js'),
     repsFullNamePage: pagesPath('representatives-full-name.js'),
     relationshipPage: pagesPath('relationship.js'),

--- a/config.js
+++ b/config.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/* eslint no-process-env: 0 */
+/* eslint no-inline-comments: 0 */
+/* eslint camelcase: 0 */
+module.exports = {
+  env: process.env.NODE_ENV,
+  postcode: {
+    hostname: process.env.NODE_ENV === 'ci' ?
+      `http://${process.env.LISTEN_HOST || '0.0.0.0'}:${process.env.PORT || 8080}/api/postcode-test` :
+      'https://postcodeinfo.service.justice.gov.uk',
+    authorization: process.env.POSTCODE_AUTH,
+    addresses: {
+      path: '/addresses',
+      param: 'postcode'
+    }
+  }
+};

--- a/config.js
+++ b/config.js
@@ -1,8 +1,6 @@
 'use strict';
 
 /* eslint no-process-env: 0 */
-/* eslint no-inline-comments: 0 */
-/* eslint camelcase: 0 */
 module.exports = {
   env: process.env.NODE_ENV,
   postcode: {

--- a/mock-postcode.js
+++ b/mock-postcode.js
@@ -1,0 +1,14 @@
+'use strict';
+const router = require('express').Router();
+
+module.exports = router.use('/api/postcode-test', (req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.status(200);
+  if (req.query.postcode === 'CR0 2EU') {
+    // eslint-disable-next-line camelcase
+    res.send(JSON.stringify([{formatted_address: '49 Sydenham Road\nCroydon\nCR0 2EU', postcode: 'CR0 2EU'}]));
+  } else {
+    res.setHeader('Content-Type', 'application/json');
+    res.send(JSON.stringify([]));
+  }
+});

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "browserify": "^12.0.1",
-    "hof-bootstrap": "UKHomeOffice/hof-bootstrap#enhancement/no-more-global",
+    "hof-bootstrap": "UKHomeOffice/hof-bootstrap#development",
     "hof-transpiler": "^0.1.0",
     "node-sass": "^3.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "browserify": "^12.0.1",
-    "hof-bootstrap": "^3.2.0",
+    "hof-bootstrap": "UKHomeOffice/hof-bootstrap#enhancement/no-more-global",
     "hof-transpiler": "^0.1.0",
     "node-sass": "^3.7.0"
   },


### PR DESCRIPTION
This a PR for the whole address lookup section.
- Three steps have been added to the route config: postcode, address-lookup and address (manual),
- The controllers for the look-up have been copied from gro and put into the common directory,
- The same for the postcode model,
- The fields for the lookup steps have been added to the common fields,
- The html templates have also been added to common,
- The custom css for the lookup has been added to the sass.,
- The config file for the lookup has been added. This has also been copied from gro.

Acceptance tests:
- The acceptance tests have been added in a single feature instead of multiple as they depend on each other. E.g. You can't get to the lookup step without first going to postcode.
- These have been added to the common acceptance tests with the next step test added to the track-application journey directory,
- The mock postcode file has been added for testing. This has also been copied from gro
